### PR TITLE
Typo on title in the windows installation markdown.

### DIFF
--- a/content/en/start/install/windows.md
+++ b/content/en/start/install/windows.md
@@ -1,5 +1,5 @@
 ---
-title: "Android Installation"
+title: "Windows Installation"
 weight: 4
 GeekdocHidden: true
 ---


### PR DESCRIPTION
Fixed the Typo in the Windows Installation markdown. 